### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/arielsrv/jooby-users-api/security/code-scanning/1](https://github.com/arielsrv/jooby-users-api/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only checks out the repository and builds a Docker image, it does not require write access. The `contents: read` permission is sufficient for this workflow.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` has the least privileges necessary for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
